### PR TITLE
vboot/generate_keys: use dasharo-sdk v1.1.0

### DIFF
--- a/vboot/generate_keys
+++ b/vboot/generate_keys
@@ -27,7 +27,7 @@ KEYS_DIRECTORY="$(readlink -f $1)"
 [ -z "$KEYS_DIRECTORY" ] && echo "KEYS_DIRECTORY not given" && usage
 
 docker run --rm -it -v $PWD:$PWD -w $PWD \
-  ghcr.io/dasharo/dasharo-sdk:v1.1.2 \
+  ghcr.io/dasharo/dasharo-sdk:v1.1.0 \
   /vboot/scripts/keygeneration/create_new_keys.sh --output "$KEYS_DIRECTORY"
 
 errorCheck "Failed to generate keys"


### PR DESCRIPTION
With v1.1.2 signing works fine, but key generation does not :) See: https://github.com/Dasharo/open-source-firmware-validation/pull/237#issuecomment-2025749706