### PR TITLE
vboot/env: temporarily use latest

### DIFF
--- a/vboot/env
+++ b/vboot/env
@@ -1,1 +1,1 @@
-CONTAINER="ghcr.io/dasharo/dasharo-sdk:v1.1.2"
+CONTAINER="ghcr.io/dasharo/dasharo-sdk:latest"


### PR DESCRIPTION
This temporarily uses `latest` because it would be available locally. The target fix should use the version that will came out of https://github.com/Dasharo/dasharo-sdk/pull/7