### PR TITLE
Clevo fixups compatibility

### DIFF
--- a/clevo/mic-switch-fixup
+++ b/clevo/mic-switch-fixup
@@ -16,8 +16,11 @@ case "$PRODUCT_NAME" in
     ;;
 esac
 
-echo "evdev:atkbd:dmi:bvn*:bvr*:svn${MANUFACTURER}:pn${PRODUCT_NAME}:*" > "$HWDB_FILE"
-echo "        KEYBOARD_KEY_81=f20" >> "$HWDB_FILE"
+{
+  printf '\n'
+  echo "evdev:atkbd:dmi:bvn*:bvr*:svn${MANUFACTURER}:pn${PRODUCT_NAME}:*"
+  echo "        KEYBOARD_KEY_81=f20"
+} >> "$HWDB_FILE"
 
 systemd-hwdb update
 udevadm trigger

--- a/clevo/touchpad-fixup
+++ b/clevo/touchpad-fixup
@@ -6,9 +6,13 @@ MANUFACTURER="$(dmidecode -s baseboard-manufacturer)"
 
 echo "Found $MANUFACTURER $PRODUCT_NAME"
 
-echo "evdev:atkbd:dmi:bvn*:bvr*:svn${MANUFACTURER}:pn${PRODUCT_NAME}:*" > "$HWDB_FILE"
-echo "        KEYBOARD_KEY_f7=191" >> "$HWDB_FILE"
-echo "        KEYBOARD_KEY_f8=191" >> "$HWDB_FILE"
+{
+  printf '\n'
+  echo "evdev:atkbd:dmi:bvn*:bvr*:svn${MANUFACTURER}:pn${PRODUCT_NAME}:*" > "$HWDB_FILE"
+  echo "        KEYBOARD_KEY_f7=191" >> "$HWDB_FILE"
+  echo "        KEYBOARD_KEY_f8=191" >> "$HWDB_FILE"
+} >> "$HWDB_FILE"
+
 
 systemd-hwdb update
 udevadm trigger


### PR DESCRIPTION
Both fixups overwrite the `60-keyboard.hmdb` file. Applying one of them reverts the changes of the other.
It makes them compatible by removing overwrites. Will the potential duplicates caused by running the scripts multiple times break anything?